### PR TITLE
Export spawn as a property as well as a function.

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,4 +62,5 @@ function spawn(command, args, options) {
     return cp.spawn(command, args, options);
 }
 
+spawn.spawn = spawn;
 module.exports = spawn;


### PR DESCRIPTION
This makes both of the following usages correct:

``` javascript
var spawn = require('cross-spawn');
spawn(/**/);
```

``` javascript
var proc = require('cross-spawn');
proc.spawn(/**/);
```

The motivation behind this is to make unit testing with libraries like [`sinon`](http://sinonjs.org/) easier. By making `spawn` a method of the module's resolved value we can easily stub it across the entire application like so:

```
var proc = require('cross-spawn');
sinon.stub(proc, 'spawn');
```

That way no changes to existing code are required in order to use a stubbed / spied-on cross-platform spawn function.
