### PR TITLE
multiple commands in single line like "git init && git remote add ..."  not working on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,20 +44,12 @@ function spawn(command, args, options) {
         return cp.spawn(command, args, options);
     }
 
-    // Escape command & arguments
-    applyQuotes = command !== 'echo';  // Do not quote arguments for the special "echo" command
-    command = escapeCommand(command);
-    args = (args || []).map(function (arg) {
-        return escapeArg(arg, applyQuotes);
-    });
-
     // Use cmd.exe
-    args = ['/s', '/c', '"' + command + (args.length ? ' ' + args.join(' ') : '') + '"'];
+    args = ['/s', '/c', command + (args && args.length ? ' ' + args.join(' ') : '')];
+
     command = 'cmd';
 
-    // Tell node's spawn that the arguments are already escaped
     options = options || {};
-    options.windowsVerbatimArguments = true;
 
     return cp.spawn(command, args, options);
 }


### PR DESCRIPTION
I have a multiple command in a single line. 

```
git init && git remote add origin address
```

I'm not sure whether there's any other way I should be doing it. 
The yeoman generator uses this in its `generator.spawnCommand` and I need to execute my commands in order and I've found that passing in different `spawnCommand` doesn't ensure that.

But this gives error "usage: git init [-q | --quiet] [-...". I guess it somehow sends the "`&& git remote...`" as an argument to `git init`.

Luckily, it executes if I pass the command as `cmd /c git init && git remote add ...`. Which seems unnecessary and redundant but it works!

What also works is NOT Escaping command & arguments in the source (attached pull request). Not sure if this is acceptable but it works.
