### PR TITLE
fix: fix paths being incorrectly normalized on unix

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -49,6 +49,10 @@ function parseNonShell(parsed) {
         // we need to double escape them
         const needsDoubleEscapeMetaChars = isCmdShimRegExp.test(commandFile);
 
+        // Normalize posix paths into OS compatible paths (e.g.: foo/bar -> foo\bar)
+        // This is necessary otherwise it will always fail with ENOENT in those cases
+        parsed.command = path.normalize(parsed.command);
+
         // Escape command & arguments
         parsed.command = escape.command(parsed.command);
         parsed.args = parsed.args.map((arg) => escape.argument(arg, needsDoubleEscapeMetaChars));
@@ -104,7 +108,7 @@ function parse(command, args, options) {
 
     // Build our parsed object
     const parsed = {
-        command: path.normalize(command),
+        command,
         args,
         options,
         file: undefined,

--- a/lib/util/resolveCommand.js
+++ b/lib/util/resolveCommand.js
@@ -4,15 +4,40 @@ const path = require('path');
 const which = require('which');
 const pathKey = require('path-key')();
 
-function resolveCommandAttempt(parsed, withPathExt) {
-    withPathExt = !!withPathExt;
+function resolveCommandAttempt(parsed, withoutPathExt) {
+    const cwd = process.cwd();
+    const hasCustomCwd = parsed.options.cwd != null;
+
+    // If a custom `cwd` was specified, we need to change the process cwd
+    // because `which` will do stat calls but does not support a custom cwd
+    if (hasCustomCwd) {
+        try {
+            process.chdir(parsed.options.cwd);
+        } catch (err) {
+            /* Empty */
+        }
+    }
+
+    let resolved;
 
     try {
-        return which.sync(parsed.command, {
+        resolved = which.sync(parsed.command, {
             path: (parsed.options.env || process.env)[pathKey],
-            pathExt: withPathExt && process.env.PATHEXT ? path.delimiter + process.env.PATHEXT : undefined,
+            pathExt: withoutPathExt ? path.delimiter : undefined,
         });
-    } catch (e) { /* Empty */ }
+    } catch (e) {
+        /* Empty */
+    } finally {
+        process.chdir(cwd);
+    }
+
+    // If we successfully resolved, ensure that an absolute path is returned
+    // Note that when a custom `cwd` was used, we need to resolve to an absolute path based on it
+    if (resolved) {
+        resolved = path.resolve(hasCustomCwd ? parsed.options.cwd : '', resolved);
+    }
+
+    return resolved;
 }
 
 function resolveCommand(parsed) {


### PR DESCRIPTION
 This actually fixes another bug with `options.cwd` on Windows.

Closes #90.