### PR TITLE
fix: avoid using deprecated Buffer constructor

### DIFF
--- a/lib/util/readShebang.js
+++ b/lib/util/readShebang.js
@@ -7,8 +7,17 @@ function readShebang(command) {
     // Read the first 150 bytes from the file
     const size = 150;
 
+    let buffer;
+    if (Buffer.alloc) {
+        // Node.js v4.5+ / v5.10+
+        buffer = Buffer.alloc(size);
+    } else {
+        // Old Node.js API
+        buffer = new Buffer(size);
+        buffer.fill(0); // zero-fill
+    }
+
     let fd;
-    const buffer = Buffer.alloc(size);
 
     try {
         fd = fs.openSync(command, 'r');

--- a/lib/util/readShebang.js
+++ b/lib/util/readShebang.js
@@ -6,7 +6,7 @@ const shebangCommand = require('shebang-command');
 function readShebang(command) {
     // Read the first 150 bytes from the file
     let fd;
-    const buffer = new Buffer(150);
+    const buffer = Buffer.alloc(150);
 
     try {
         fd = fs.openSync(command, 'r');

--- a/lib/util/readShebang.js
+++ b/lib/util/readShebang.js
@@ -5,12 +5,14 @@ const shebangCommand = require('shebang-command');
 
 function readShebang(command) {
     // Read the first 150 bytes from the file
+    const size = 150;
+
     let fd;
-    const buffer = Buffer.alloc(150);
+    const buffer = Buffer.alloc(size);
 
     try {
         fd = fs.openSync(command, 'r');
-        fs.readSync(fd, buffer, 0, 150, 0);
+        fs.readSync(fd, buffer, 0, size, 0);
         fs.closeSync(fd);
     } catch (e) { /* Empty */ }
 


### PR DESCRIPTION
Buffer.alloc() is supported on Node.js >= 4.5.0, and allocates a zero-filled
buffer on all supported versions.

This solves two issues:
 * Buffer() constructor (aka 'new Buffer()') is deprecated, so avoid using it
 * On 4.x and 6.x, Buffer(number) is not zero-filled, so this code was
   allocating an uninitialized Buffer when file length was less than 150, so
   the behaviour of readShebang() was actually undefined in that case (as in
   could have returned anything, depending on the uninitialized memory chunk).

Refs: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor

Note: I have not run tests on this, but expect no issues. CI should verify that.