### PR TITLE
remove 'nice-try' dependency

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('path');
-const niceTry = require('nice-try');
 const resolveCommand = require('./util/resolveCommand');
 const escape = require('./util/escape');
 const readShebang = require('./util/readShebang');
@@ -10,6 +9,7 @@ const semver = require('semver');
 const isWin = process.platform === 'win32';
 const isExecutableRegExp = /\.(?:com|exe)$/i;
 const isCmdShimRegExp = /node_modules[\\/].bin[\\/][^\\/]+\.cmd$/i;
+const niceTry = (fn) => { try { return fn() } catch (e) {} };
 
 // `options.shell` is supported in Node ^4.8.0, ^5.7.0 and >= 6.0.0
 const supportsShellOption = niceTry(() => semver.satisfies(process.version, '^4.8.0 || ^5.7.0 || >= 6.0.0', true)) || false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6788,11 +6788,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "nice-try": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
-      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
-    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     ]
   },
   "dependencies": {
-    "nice-try": "^1.0.4",
     "path-key": "^2.0.1",
     "semver": "^5.5.0",
     "shebang-command": "^1.2.0",


### PR DESCRIPTION
`node-cross-spawn` is a dependency of 2431 packages, including highly popular packages `eslint` or  `webpack-cli`.

This means that the package itself should reduce its own dependencies to the bare minimum.

The `nice-try` package does nothing but swallowing the error of the invoked function.
It should never be considered as an external dependency - it is too brittle.
Now, `nice-try` found its way to be included in most of the projects that use eslint or webpack which is totally unnecessary.

Hence, I propose to remove the dependency.