### PR TITLE
Inline dependencies path-key and shebang-command

### DIFF
--- a/lib/util/pathEnv.js
+++ b/lib/util/pathEnv.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const pathKey = (options = {}) => {
+    const environment = options.env || process.env;
+    const platform = options.platform || process.platform;
+
+    if (platform !== 'win32') {
+        return 'PATH';
+    }
+
+    return Object.keys(environment).find((key) => key.toUpperCase() === 'PATH') || 'Path';
+};
+
+const pathEnv = (options = null) => {
+    const key = pathKey(options);
+
+    if (options === null) {
+        return process.env[key];
+    }
+
+    return options.env[key];
+};
+
+module.exports.pathKey = pathKey;
+module.exports.pathEnv = pathEnv;

--- a/lib/util/readShebang.js
+++ b/lib/util/readShebang.js
@@ -1,7 +1,23 @@
 'use strict';
 
 const fs = require('fs');
-const shebangCommand = require('shebang-command');
+
+function parseShebangCommand(string = '') {
+    const match = string.match(/^#!(.*)/);
+
+    if (!match) {
+        return null;
+    }
+
+    const [path, argument] = match[0].replace(/#! ?/, '').split(' ');
+    const binary = path.split('/').pop();
+
+    if (binary === 'env') {
+        return argument;
+    }
+
+    return argument ? `${binary} ${argument}` : binary;
+}
 
 function readShebang(command) {
     // Read the first 150 bytes from the file
@@ -14,10 +30,12 @@ function readShebang(command) {
         fd = fs.openSync(command, 'r');
         fs.readSync(fd, buffer, 0, size, 0);
         fs.closeSync(fd);
-    } catch (e) { /* Empty */ }
+    } catch (e) {
+        /* Empty */
+    }
 
     // Attempt to extract shebang (null is returned if not a shebang)
-    return shebangCommand(buffer.toString());
+    return parseShebangCommand(buffer.toString());
 }
 
 module.exports = readShebang;

--- a/lib/util/resolveCommand.js
+++ b/lib/util/resolveCommand.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const which = require('which');
-const pathKey = require('path-key')();
+const pathEnv = require('./pathEnv').pathEnv;
 
 function resolveCommandAttempt(parsed, withoutPathExt) {
     const cwd = process.cwd();
@@ -22,7 +22,7 @@ function resolveCommandAttempt(parsed, withoutPathExt) {
 
     try {
         resolved = which.sync(parsed.command, {
-            path: (parsed.options.env || process.env)[pathKey],
+            path: pathEnv(parsed.options),
             pathExt: withoutPathExt ? path.delimiter : undefined,
         });
     } catch (e) {

--- a/package.json
+++ b/package.json
@@ -52,8 +52,6 @@
     ]
   },
   "dependencies": {
-    "path-key": "^3.1.0",
-    "shebang-command": "^1.2.0",
     "which": "^1.2.9"
   },
   "devDependencies": {

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -3,7 +3,6 @@
     "extends": [
         "eslint-config-moxy/es8",
         "eslint-config-moxy/addons/node",
-        "eslint-config-moxy/addons/object-spread",
         "eslint-config-moxy/addons/jest"
     ]
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const rimraf = require('rimraf');
 const mkdirp = require('mkdirp');
 const childProcess = require('child_process');
-const pathKey = require('path-key')();
+const pathKey = require('../lib/util/pathEnv').pathKey();
 const run = require('./util/run');
 
 const isWin = process.platform === 'win32';
@@ -27,18 +27,18 @@ run.methods.forEach((method) => {
         });
 
         it('should expand using PATHEXT properly', async () => {
-            const { stdout } = await run(method, `${__dirname}/fixtures/say-foo`);
+            const {stdout} = await run(method, `${__dirname}/fixtures/say-foo`);
 
             expect(stdout.trim()).toBe('foo');
         });
 
         it('should support shebang in executables with `/usr/bin/env`', async () => {
-            const { stdout: stdout1 } = await run(method, `${__dirname}/fixtures/shebang`);
+            const {stdout: stdout1} = await run(method, `${__dirname}/fixtures/shebang`);
 
             expect(stdout1).toBe('shebang works!');
 
             // Test if the actual shebang file is resolved against the options.env.PATH
-            const { stdout: stdout2 } = await run(method, 'shebang', {
+            const {stdout: stdout2} = await run(method, 'shebang', {
                 env: {
                     ...process.env,
                     [pathKey]: path.normalize(`${__dirname}/fixtures`) + path.delimiter + process.env[pathKey],
@@ -57,12 +57,12 @@ run.methods.forEach((method) => {
                 const originalSpawnSync = childProcess.spawnSync;
 
                 jest.spyOn(childProcess, 'spawn').mockImplementation((command, args, options) =>
-                    originalSpawn(command, args, { ...options, env: process.env }));
+                    originalSpawn(command, args, {...options, env: process.env}));
                 jest.spyOn(childProcess, 'spawnSync').mockImplementation((command, args, options) =>
-                    originalSpawnSync(command, args, { ...options, env: process.env }));
+                    originalSpawnSync(command, args, {...options, env: process.env}));
             }
 
-            const { stdout: stdout3 } = await run(method, 'shebang');
+            const {stdout: stdout3} = await run(method, 'shebang');
 
             expect(stdout3).toBe('shebang works!');
         });
@@ -71,20 +71,20 @@ run.methods.forEach((method) => {
             fs.writeFileSync(
                 `${__dirname}/fixtures/()%!^&;, `,
                 fs.readFileSync(`${__dirname}/fixtures/pre_()%!^&;, .sh`),
-                { mode: 0o0777 }
+                {mode: 0o0777}
             );
             fs.writeFileSync(
                 `${__dirname}/fixtures/()%!^&;, .bat`,
                 fs.readFileSync(`${__dirname}/fixtures/pre_()%!^&;, .bat`)
             );
 
-            const { stdout } = await run(method, `${__dirname}/fixtures/()%!^&;, `);
+            const {stdout} = await run(method, `${__dirname}/fixtures/()%!^&;, `);
 
             expect(stdout.trim()).toBe('special');
         });
 
         it('should handle empty arguments and arguments with spaces', async () => {
-            const { stdout } = await run(method, 'node', [
+            const {stdout} = await run(method, 'node', [
                 `${__dirname}/fixtures/echo`,
                 'foo',
                 '',
@@ -96,7 +96,7 @@ run.methods.forEach((method) => {
         });
 
         it('should handle non-string arguments', async () => {
-            const { stdout } = await run(method, 'node', [
+            const {stdout} = await run(method, 'node', [
                 `${__dirname}/fixtures/echo`,
                 1234,
             ]);
@@ -140,7 +140,7 @@ run.methods.forEach((method) => {
                 '"(foo|bar>baz|foz)"',
             ];
 
-            const { stdout } = await run(method, 'node', [`${__dirname}/fixtures/echo`].concat(args));
+            const {stdout} = await run(method, 'node', [`${__dirname}/fixtures/echo`].concat(args));
 
             expect(stdout).toBe(args.join('\n'));
         });
@@ -153,28 +153,28 @@ run.methods.forEach((method) => {
 
                 const arg = '"(foo|bar>baz|foz)"';
 
-                const { stdout } = await run(method, `${__dirname}/fixtures/node_modules/.bin/echo-cmd-shim`, [arg]);
+                const {stdout} = await run(method, `${__dirname}/fixtures/node_modules/.bin/echo-cmd-shim`, [arg]);
 
                 expect(stdout).toBe(arg);
             });
         }
 
         it('should handle commands with names of environment variables', async () => {
-            const { stdout } = await run(method, `${__dirname}/fixtures/%CD%`);
+            const {stdout} = await run(method, `${__dirname}/fixtures/%CD%`);
 
             expect(stdout.trim()).toBe('special');
         });
 
         it('should handle optional spawn optional arguments correctly', async () => {
-            const { stdout: stdout1 } = await run(method, `${__dirname}/fixtures/say-foo`);
+            const {stdout: stdout1} = await run(method, `${__dirname}/fixtures/say-foo`);
 
             expect(stdout1.trim()).toBe('foo');
 
-            const { stdout: stdout2 } = await run(method, `${__dirname}/fixtures/say-foo`, { stdio: 'ignore' });
+            const {stdout: stdout2} = await run(method, `${__dirname}/fixtures/say-foo`, {stdio: 'ignore'});
 
             expect(stdout2).toBe(null);
 
-            const { stdout: stdout3 } = await run(method, `${__dirname}/fixtures/say-foo`, null, { stdio: 'ignore' });
+            const {stdout: stdout3} = await run(method, `${__dirname}/fixtures/say-foo`, null, {stdio: 'ignore'});
 
             expect(stdout3).toBe(null);
         });
@@ -202,11 +202,11 @@ run.methods.forEach((method) => {
         it('should work with a relative posix path to a command', async () => {
             const relativeFixturesPath = path.relative(process.cwd(), `${__dirname}/fixtures`).replace(/\\/, '/');
 
-            const { stdout: stdout1 } = await run(method, `${relativeFixturesPath}/say-foo`);
+            const {stdout: stdout1} = await run(method, `${relativeFixturesPath}/say-foo`);
 
             expect(stdout1.trim()).toBe('foo');
 
-            const { stdout: stdout2 } = await run(method, `./${relativeFixturesPath}/say-foo`);
+            const {stdout: stdout2} = await run(method, `./${relativeFixturesPath}/say-foo`);
 
             expect(stdout2.trim()).toBe('foo');
 
@@ -214,7 +214,7 @@ run.methods.forEach((method) => {
                 return;
             }
 
-            const { stdout: stdout3 } = await run(method, `./${relativeFixturesPath}/say-foo.bat`);
+            const {stdout: stdout3} = await run(method, `./${relativeFixturesPath}/say-foo.bat`);
 
             expect(stdout3.trim()).toBe('foo');
         });
@@ -222,11 +222,11 @@ run.methods.forEach((method) => {
         it('should work with a relative posix path to a command with a custom `cwd`', async () => {
             const relativeTestPath = path.relative(process.cwd(), __dirname).replace(/\\/, '/');
 
-            const { stdout: stdout1 } = await run(method, 'fixtures/say-foo', { cwd: relativeTestPath });
+            const {stdout: stdout1} = await run(method, 'fixtures/say-foo', {cwd: relativeTestPath});
 
             expect(stdout1.trim()).toBe('foo');
 
-            const { stdout: stdout2 } = await run(method, './fixtures/say-foo', { cwd: `./${relativeTestPath}` });
+            const {stdout: stdout2} = await run(method, './fixtures/say-foo', {cwd: `./${relativeTestPath}`});
 
             expect(stdout2.trim()).toBe('foo');
 
@@ -234,7 +234,7 @@ run.methods.forEach((method) => {
                 return;
             }
 
-            const { stdout: stdout3 } = await run(method, './fixtures/say-foo.bat', { cwd: `./${relativeTestPath}` });
+            const {stdout: stdout3} = await run(method, './fixtures/say-foo.bat', {cwd: `./${relativeTestPath}`});
 
             expect(stdout3.trim()).toBe('foo');
         });
@@ -270,25 +270,26 @@ run.methods.forEach((method) => {
 
                     await new Promise((resolve, reject) => {
                         const promise = run(method, 'somecommandthatwillneverexist', ['foo']);
-                        const { cp } = promise;
+                        const {cp} = promise;
 
-                        promise.catch(() => {});
+                        promise.catch(() => {
+                        });
 
                         let timeout;
 
                         cp
-                        .on('error', assertError)
-                        .on('exit', () => {
-                            cp.removeAllListeners();
-                            clearTimeout(timeout);
-                            reject(new Error('Should not emit exit'));
-                        })
-                        .on('close', (code, signal) => {
-                            expect(code).not.toBe(0);
-                            expect(signal).toBe(null);
+                            .on('error', assertError)
+                            .on('exit', () => {
+                                cp.removeAllListeners();
+                                clearTimeout(timeout);
+                                reject(new Error('Should not emit exit'));
+                            })
+                            .on('close', (code, signal) => {
+                                expect(code).not.toBe(0);
+                                expect(signal).toBe(null);
 
-                            timeout = setTimeout(resolve, 1000);
-                        });
+                                timeout = setTimeout(resolve, 1000);
+                            });
                     });
                 });
             }
@@ -308,28 +309,30 @@ run.methods.forEach((method) => {
             it('should NOT emit `error` if the command actual exists but exited with 1', async () => {
                 await new Promise((resolve, reject) => {
                     const promise = run(method, `${__dirname}/fixtures/exit-1`);
-                    const { cp } = promise;
+                    const {cp} = promise;
 
-                    promise.catch(() => {});
+                    promise.catch(() => {
+                    });
 
-                    const onExit = jest.fn(() => {});
+                    const onExit = jest.fn(() => {
+                    });
                     let timeout;
 
                     cp
-                    .on('error', () => {
-                        cp.removeAllListeners();
-                        clearTimeout(timeout);
-                        reject(new Error('Should not emit error'));
-                    })
-                    .on('exit', onExit)
-                    .on('close', (code, signal) => {
-                        expect(code).toBe(1);
-                        expect(signal).toBe(null);
-                        expect(onExit).toHaveBeenCalledTimes(1);
-                        expect(onExit).toHaveBeenCalledWith(1, null);
+                        .on('error', () => {
+                            cp.removeAllListeners();
+                            clearTimeout(timeout);
+                            reject(new Error('Should not emit error'));
+                        })
+                        .on('exit', onExit)
+                        .on('close', (code, signal) => {
+                            expect(code).toBe(1);
+                            expect(signal).toBe(null);
+                            expect(onExit).toHaveBeenCalledTimes(1);
+                            expect(onExit).toHaveBeenCalledWith(1, null);
 
-                        timeout = setTimeout(resolve, 1000);
-                    });
+                            timeout = setTimeout(resolve, 1000);
+                        });
                 });
             });
         }
@@ -348,28 +351,30 @@ run.methods.forEach((method) => {
             it('should NOT emit `error` if shebang command does not exist', async () => {
                 await new Promise((resolve, reject) => {
                     const promise = run(method, `${__dirname}/fixtures/shebang-enoent`);
-                    const { cp } = promise;
+                    const {cp} = promise;
 
-                    promise.catch(() => {});
+                    promise.catch(() => {
+                    });
 
-                    const onExit = jest.fn(() => {});
+                    const onExit = jest.fn(() => {
+                    });
                     let timeout;
 
                     cp
-                    .on('error', () => {
-                        cp.removeAllListeners();
-                        clearTimeout(timeout);
-                        reject(new Error('Should not emit error'));
-                    })
-                    .on('exit', onExit)
-                    .on('close', (code, signal) => {
-                        expect(code).not.toBe(0);
-                        expect(signal).toBe(null);
-                        expect(onExit).toHaveBeenCalledTimes(1);
-                        expect(onExit).not.toHaveBeenCalledWith(0, null);
+                        .on('error', () => {
+                            cp.removeAllListeners();
+                            clearTimeout(timeout);
+                            reject(new Error('Should not emit error'));
+                        })
+                        .on('exit', onExit)
+                        .on('close', (code, signal) => {
+                            expect(code).not.toBe(0);
+                            expect(signal).toBe(null);
+                            expect(onExit).toHaveBeenCalledTimes(1);
+                            expect(onExit).not.toHaveBeenCalledWith(0, null);
 
-                        timeout = setTimeout(resolve, 1000);
-                    });
+                            timeout = setTimeout(resolve, 1000);
+                        });
                 });
             });
         }
@@ -379,7 +384,7 @@ run.methods.forEach((method) => {
                 expect.assertions(1);
 
                 try {
-                    run(method, 'fixtures/say-foo', { cwd: 'somedirthatwillneverexist' });
+                    run(method, 'fixtures/say-foo', {cwd: 'somedirthatwillneverexist'});
                 } catch (err) {
                     expect(err.code).toBe('ENOENT');
                 }
@@ -390,38 +395,39 @@ run.methods.forEach((method) => {
 
                 await new Promise((resolve, reject) => {
                     const promise = run(method, 'somecommandthatwillneverexist', ['foo']);
-                    const { cp } = promise;
+                    const {cp} = promise;
 
-                    promise.catch(() => {});
+                    promise.catch(() => {
+                    });
 
                     let timeout;
 
                     cp
-                    .on('error', (err) => expect(err.code).toBe('ENOENT'))
-                    .on('exit', () => {
-                        cp.removeAllListeners();
-                        clearTimeout(timeout);
-                        reject(new Error('Should not emit exit'));
-                    })
-                    .on('close', (code, signal) => {
-                        expect(code).not.toBe(0);
-                        expect(signal).toBe(null);
+                        .on('error', (err) => expect(err.code).toBe('ENOENT'))
+                        .on('exit', () => {
+                            cp.removeAllListeners();
+                            clearTimeout(timeout);
+                            reject(new Error('Should not emit exit'));
+                        })
+                        .on('close', (code, signal) => {
+                            expect(code).not.toBe(0);
+                            expect(signal).toBe(null);
 
-                        timeout = setTimeout(resolve, 1000);
-                    });
+                            timeout = setTimeout(resolve, 1000);
+                        });
                 });
             });
         }
 
         if (isWin) {
             it('should use nodejs\' spawn when options.shell is specified (windows)', async () => {
-                const { stdout } = await run(method, 'echo', ['%RANDOM%'], { shell: true });
+                const {stdout} = await run(method, 'echo', ['%RANDOM%'], {shell: true});
 
                 expect(stdout.trim()).toMatch(/\d+/);
             });
         } else {
             it('should use nodejs\' spawn when options.shell is specified (linux)', async () => {
-                const { stdout } = await run(method, 'echo', ['hello &&', 'echo there'], { shell: true });
+                const {stdout} = await run(method, 'echo', ['hello &&', 'echo there'], {shell: true});
 
                 expect(stdout.trim()).toEqual('hello\nthere');
             });
@@ -429,7 +435,7 @@ run.methods.forEach((method) => {
 
         if (isWin && !run.isForceShell(method)) {
             it('should NOT spawn a shell for a .exe', async () => {
-                const { stdout } = await run(method, `${__dirname}/fixtures/win-ppid.js`);
+                const {stdout} = await run(method, `${__dirname}/fixtures/win-ppid.js`);
 
                 expect(Number(stdout.trim())).toBe(process.pid);
             });


### PR DESCRIPTION
Inlined three dependencies in total, (`path-key`, `shebang-command`, and `shebang-regex`)
[The regex](https://github.com/sindresorhus/shebang-regex/blob/master/index.js#L2) of `shebang-regex` being only 9 byte but coming with a package.json, typescript definition and LICENSE file for a total of 2 828 byte (**314 times bigger !**)

Also fixed eslint config which gave this error
`Error: Cannot find module 'eslint-config-moxy/addons/object-spread'`
and ran
`eslint . --fix`