### PR TITLE
Support worker threads

### DIFF
--- a/lib/util/resolveCommand.js
+++ b/lib/util/resolveCommand.js
@@ -7,10 +7,12 @@ const pathKey = require('path-key')();
 function resolveCommandAttempt(parsed, withoutPathExt) {
     const cwd = process.cwd();
     const hasCustomCwd = parsed.options.cwd != null;
+    // Worker threads do not have process.chdir()
+    const shouldSwitchCwd = hasCustomCwd && process.chdir !== undefined;
 
     // If a custom `cwd` was specified, we need to change the process cwd
     // because `which` will do stat calls but does not support a custom cwd
-    if (hasCustomCwd) {
+    if (shouldSwitchCwd) {
         try {
             process.chdir(parsed.options.cwd);
         } catch (err) {
@@ -28,7 +30,9 @@ function resolveCommandAttempt(parsed, withoutPathExt) {
     } catch (e) {
         /* Empty */
     } finally {
-        process.chdir(cwd);
+        if (shouldSwitchCwd) {
+            process.chdir(cwd);
+        }
     }
 
     // If we successfully resolved, ensure that an absolute path is returned


### PR DESCRIPTION
Fixes #124 and https://github.com/sindresorhus/execa/issues/357

This library currently does not work inside worker threads because of the use of `process.chdir()`. This fixes that.