### PR TITLE
fix(core): fix worker threads in Node `>=11.10.0`

### DIFF
--- a/lib/util/resolveCommand.js
+++ b/lib/util/resolveCommand.js
@@ -8,7 +8,7 @@ function resolveCommandAttempt(parsed, withoutPathExt) {
     const cwd = process.cwd();
     const hasCustomCwd = parsed.options.cwd != null;
     // Worker threads do not have process.chdir()
-    const shouldSwitchCwd = hasCustomCwd && process.chdir !== undefined;
+    const shouldSwitchCwd = hasCustomCwd && process.chdir !== undefined && !process.chdir.disabled;
 
     // If a custom `cwd` was specified, we need to change the process cwd
     // because `which` will do stat calls but does not support a custom cwd


### PR DESCRIPTION
Fixes #130.

Follow up on #127.

In worker threads, `process.chdir` used to be `undefined`. However since Node `11.10.0` it is now a noop function with a `disabled: true` property.