### PR TITLE
fix: detect path key based on correct environment

### DIFF
--- a/lib/util/resolveCommand.js
+++ b/lib/util/resolveCommand.js
@@ -2,9 +2,10 @@
 
 const path = require('path');
 const which = require('which');
-const pathKey = require('path-key')();
+const getPathKey = require('path-key');
 
 function resolveCommandAttempt(parsed, withoutPathExt) {
+    const env = parsed.options.env || process.env;
     const cwd = process.cwd();
     const hasCustomCwd = parsed.options.cwd != null;
     // Worker threads do not have process.chdir()
@@ -24,7 +25,7 @@ function resolveCommandAttempt(parsed, withoutPathExt) {
 
     try {
         resolved = which.sync(parsed.command, {
-            path: (parsed.options.env || process.env)[pathKey],
+            path: env[getPathKey({ env })],
             pathExt: withoutPathExt ? path.delimiter : undefined,
         });
     } catch (e) {

--- a/test/fixtures/whoami.cmd
+++ b/test/fixtures/whoami.cmd
@@ -1,0 +1,2 @@
+@echo off
+echo you sure are someone

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -434,5 +434,22 @@ run.methods.forEach((method) => {
                 expect(Number(stdout.trim())).toBe(process.pid);
             });
         }
+
+        if (isWin) {
+            const differentPathKey = pathKey.startsWith('p') ? 'PATH' : 'path';
+
+            it('should work if the path key is different in options.env', async () => {
+                const env = {
+                    ...process.env,
+                    [differentPathKey]: `${__dirname}\\fixtures;${process.env[pathKey]}`,
+                };
+
+                delete env[pathKey];
+
+                const { stdout } = await run(method, 'whoami', { env });
+
+                expect(stdout.trim()).toBe('you sure are someone');
+            });
+        }
     });
 });


### PR DESCRIPTION
Scenario:

Windows machine with `Path` environment key containing the PATH. An environment is passed in where the PATH is named `PATH`.
`cross-spawn` will pass an undefined `path` into `which`, which makes `which` fall back to `process.env.Path`.

This is troublesome if the first hit in `options.env.PATH` is not an executable file but the first hit in `process.env.Path` is an executable file. `cross-spawn` doesn't realise it needs to wrap the command with `cmd.exe`.

We're running into this in yarnpkg/berry#1377, where we prepend the PATH with a folder containing `node.cmd` but `cross-spawn` detects `C:\Program Files\nodejs\node.exe` instead.