### PR TITLE
fix: disable regexp backtracking

### DIFF
--- a/lib/util/escape.js
+++ b/lib/util/escape.js
@@ -15,15 +15,17 @@ function escapeArgument(arg, doubleEscapeMetaChars) {
     arg = `${arg}`;
 
     // Algorithm below is based on https://qntm.org/cmd
+    // It's slightly altered to disable JS backtracking to avoid hanging on specially crafted input
+    // Please see https://github.com/moxystudio/node-cross-spawn/pull/160 for more information
 
     // Sequence of backslashes followed by a double quote:
     // double up all the backslashes and escape the double quote
-    arg = arg.replace(/(\\*)"/g, '$1$1\\"');
+    arg = arg.replace(/(?=\\*?)"/g, '$1$1\\"');
 
     // Sequence of backslashes followed by the end of the string
     // (which will become a double quote later):
     // double up all the backslashes
-    arg = arg.replace(/(\\*)$/, '$1$1');
+    arg = arg.replace(/(?=\\*?)$/, '$1$1');
 
     // All other backslashes occur literally
 


### PR DESCRIPTION
With a very large and well crafted string, the escaping made by cross-spawn hangs forever.

```js
const { argument } = require('cross-spawn/lib/util/escape');
var str = "";
for (var i = 0; i < 1000000; i++) {
  str += "\\";
}
str += "◎";

console.log("start")
argument(str)
console.log("end")
```

This PR disables regexp back tracking so that it doesn't suffer from this. https://javascript.info/regexp-catastrophic-backtracking for more details.

