### PR TITLE
fix: update cross-spawn version to 7.0.5 in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "cross-spawn",
-      "version": "7.0.3",
+      "version": "7.0.5",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",


### PR DESCRIPTION
The version in package.json has been updated, but the version in the lockfile has not been updated.

If you cannot update the version from 7.0.5, you will probably need to upgrade to 7.0.6.